### PR TITLE
Implement cat log file rotation

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -1777,59 +1777,169 @@ end}.
          rabbit_prelaunch_early_logging:translate_formatter_conf("log.file.formatter", Conf)
  end}.
 
-%% Log categories
-
+%% Connection log.
 {mapping, "log.connection.level", "rabbit.log.categories.connection.level", [
     {datatype, {enum, [debug, info, notice, warning, error, critical, alert, emergency, none]}}
 ]}.
 {mapping, "log.connection.file", "rabbit.log.categories.connection.file", [
     {datatype, string}
 ]}.
+{mapping, "log.connection.rotation.date", "rabbit.log.categories.connection.rotate_on_date", [
+    {datatype, string}
+]}.
+{mapping, "log.connection.rotation.compress", "rabbit.log.categories.connection.compress_on_rotate", [
+    {default, false},
+    {datatype, {enum, [true, false]}}
+]}.
+{mapping, "log.connection.rotation.size", "rabbit.log.categories.connection.max_no_bytes", [
+    {datatype, integer}
+]}.
+{mapping, "log.connection.rotation.count", "rabbit.log.categories.connection.max_no_files", [
+    {datatype, integer}
+]}.
 
+%% Channel log.
 {mapping, "log.channel.level", "rabbit.log.categories.channel.level", [
     {datatype, {enum, [debug, info, notice, warning, error, critical, alert, emergency, none]}}
 ]}.
 {mapping, "log.channel.file", "rabbit.log.categories.channel.file", [
     {datatype, string}
 ]}.
+{mapping, "log.channel.rotation.date", "rabbit.log.categories.channel.rotate_on_date", [
+    {datatype, string}
+]}.
+{mapping, "log.channel.rotation.compress", "rabbit.log.categories.channel.compress_on_rotate", [
+    {default, false},
+    {datatype, {enum, [true, false]}}
+]}.
+{mapping, "log.channel.rotation.size", "rabbit.log.categories.channel.max_no_bytes", [
+    {datatype, integer}
+]}.
+{mapping, "log.channel.rotation.count", "rabbit.log.categories.channel.max_no_files", [
+    {datatype, integer}
+]}.
 
+%% Mirroring log.
 {mapping, "log.mirroring.level", "rabbit.log.categories.mirroring.level", [
     {datatype, {enum, [debug, info, notice, warning, error, critical, alert, emergency, none]}}
 ]}.
 {mapping, "log.mirroring.file", "rabbit.log.categories.mirroring.file", [
     {datatype, string}
 ]}.
+{mapping, "log.mirroring.rotation.date", "rabbit.log.categories.mirroring.rotate_on_date", [
+    {datatype, string}
+]}.
+{mapping, "log.mirroring.rotation.compress", "rabbit.log.categories.mirroring.compress_on_rotate", [
+    {default, false},
+    {datatype, {enum, [true, false]}}
+]}.
+{mapping, "log.mirroring.rotation.size", "rabbit.log.categories.mirroring.max_no_bytes", [
+    {datatype, integer}
+]}.
+{mapping, "log.mirroring.rotation.count", "rabbit.log.categories.mirroring.max_no_files", [
+    {datatype, integer}
+]}.
 
+%% Queue log.
 {mapping, "log.queue.level", "rabbit.log.categories.queue.level", [
     {datatype, {enum, [debug, info, notice, warning, error, critical, alert, emergency, none]}}
 ]}.
 {mapping, "log.queue.file", "rabbit.log.categories.queue.file", [
     {datatype, string}
 ]}.
+{mapping, "log.queue.rotation.date", "rabbit.log.categories.queue.rotate_on_date", [
+    {datatype, string}
+]}.
+{mapping, "log.queue.rotation.compress", "rabbit.log.categories.queue.compress_on_rotate", [
+    {default, false},
+    {datatype, {enum, [true, false]}}
+]}.
+{mapping, "log.queue.rotation.size", "rabbit.log.categories.queue.max_no_bytes", [
+    {datatype, integer}
+]}.
+{mapping, "log.queue.rotation.count", "rabbit.log.categories.queue.max_no_files", [
+    {datatype, integer}
+]}.
 
+%% Federation log.
 {mapping, "log.federation.level", "rabbit.log.categories.federation.level", [
     {datatype, {enum, [debug, info, notice, warning, error, critical, alert, emergency, none]}}
 ]}.
 {mapping, "log.federation.file", "rabbit.log.categories.federation.file", [
     {datatype, string}
 ]}.
+{mapping, "log.federation.rotation.date", "rabbit.log.categories.federation.rotate_on_date", [
+    {datatype, string}
+]}.
+{mapping, "log.federation.rotation.compress", "rabbit.log.categories.federation.compress_on_rotate", [
+    {default, false},
+    {datatype, {enum, [true, false]}}
+]}.
+{mapping, "log.federation.rotation.size", "rabbit.log.categories.federation.max_no_bytes", [
+    {datatype, integer}
+]}.
+{mapping, "log.federation.rotation.count", "rabbit.log.categories.federation.max_no_files", [
+    {datatype, integer}
+]}.
 
+%% Upgrade log.
 {mapping, "log.upgrade.level", "rabbit.log.categories.upgrade.level", [
     {datatype, {enum, [debug, info, notice, warning, error, critical, alert, emergency, none]}}
 ]}.
 {mapping, "log.upgrade.file", "rabbit.log.categories.upgrade.file", [
     {datatype, string}
 ]}.
+{mapping, "log.upgrade.rotation.date", "rabbit.log.categories.upgrade.rotate_on_date", [
+    {datatype, string}
+]}.
+{mapping, "log.upgrade.rotation.compress", "rabbit.log.categories.upgrade.compress_on_rotate", [
+    {default, false},
+    {datatype, {enum, [true, false]}}
+]}.
+{mapping, "log.upgrade.rotation.size", "rabbit.log.categories.upgrade.max_no_bytes", [
+    {datatype, integer}
+]}.
+{mapping, "log.upgrade.rotation.count", "rabbit.log.categories.upgrade.max_no_files", [
+    {datatype, integer}
+]}.
 
+%% Ra log.
 {mapping, "log.ra.level", "rabbit.log.categories.ra.level", [
     {datatype, {enum, [debug, info, notice, warning, error, critical, alert, emergency, none]}}
 ]}.
 {mapping, "log.ra.file", "rabbit.log.categories.ra.file", [
     {datatype, string}
 ]}.
+{mapping, "log.ra.rotation.date", "rabbit.log.categories.ra.rotate_on_date", [
+    {datatype, string}
+]}.
+{mapping, "log.ra.rotation.compress", "rabbit.log.categories.ra.compress_on_rotate", [
+    {default, false},
+    {datatype, {enum, [true, false]}}
+]}.
+{mapping, "log.ra.rotation.size", "rabbit.log.categories.ra.max_no_bytes", [
+    {datatype, integer}
+]}.
+{mapping, "log.ra.rotation.count", "rabbit.log.categories.ra.max_no_files", [
+    {datatype, integer}
+]}.
 
+%% Default logging config.
 {mapping, "log.default.level", "rabbit.log.categories.default.level", [
     {datatype, {enum, [debug, info, notice, warning, error, critical, alert, emergency, none]}}
+]}.
+{mapping, "log.default.rotation.date", "rabbit.log.categories.default.rotate_on_date", [
+    {datatype, string}
+]}.
+{mapping, "log.default.rotation.compress", "rabbit.log.categories.default.compress_on_rotate", [
+    {default, false},
+    {datatype, {enum, [true, false]}}
+]}.
+{mapping, "log.default.rotation.size", "rabbit.log.categories.default.max_no_bytes", [
+    {datatype, integer}
+]}.
+{mapping, "log.default.rotation.count", "rabbit.log.categories.default.max_no_files", [
+    {datatype, integer}
 ]}.
 
 % ==========================

--- a/deps/rabbit/src/rabbit_prelaunch_logging.erl
+++ b/deps/rabbit/src/rabbit_prelaunch_logging.erl
@@ -149,6 +149,7 @@
 -type file_props() :: [{level, logger:level()} |
                        {file, file:filename() | false} |
                        {date, string()} |
+                       {compress, boolean()} |
                        {size, non_neg_integer()} |
                        {count, non_neg_integer()} |
                        {formatter, {atom(), term()}}].
@@ -180,10 +181,22 @@
 %% A per-category log environment is the parameters in the configuration file
 %% for a specific category log handler. There can be one per category.
 
--type default_cat_env() :: [{level, logger:level()}].
+-type default_cat_env() :: [{level, logger:level()} |
+                            {rotate_on_date, string()} |
+                            {compress_on_rotate, boolean()} |
+                            {max_no_bytes, non_neg_integer()} |
+                            {max_no_files, non_neg_integer()}].
 %% The `default' category log environment is special (read: awkward) in the
 %% configuration file. It is used to change the log level of the main log
 %% handler.
+
+-type file_rotation_spec() :: #{type := file,
+                                rotate_on_date => string(),
+                                compress_on_rotate => boolean(),
+                                max_no_bytes => non_neg_integer(),
+                                max_no_files => non_neg_integer()}.
+%% Rotation spec is the part of logger_std_h config that defines log file rotation. See
+%% `extract_file_rotation_spec/1'.
 
 -type log_app_env() :: [main_log_env() |
                         {categories, [{default, default_cat_env()} |
@@ -534,14 +547,15 @@ get_log_configuration_from_app_env() ->
     DefaultAndCatProps = proplists:get_value(categories, Env, []),
     DefaultProps = proplists:get_value(default, DefaultAndCatProps, []),
     CatProps = proplists:delete(default, DefaultAndCatProps),
+    DefaultFileSpec = extract_file_rotation_spec(DefaultProps),
 
     %% This "normalization" turns the RabbitMQ-specific configuration into a
     %% structure which stores Logger handler configurations. That structure is
     %% later modified to reach the final handler configurations.
     PerCatConfig = maps:from_list(
-                     [{Cat, normalize_per_cat_log_config(Props)}
+                     [{Cat, normalize_per_cat_log_config(Props, DefaultFileSpec)}
                       || {Cat, Props} <- CatProps]),
-    GlobalConfig = normalize_main_log_config(EnvWithoutCats, DefaultProps),
+    GlobalConfig = normalize_main_log_config(EnvWithoutCats, DefaultProps, DefaultFileSpec),
     #{global => GlobalConfig,
       per_category => PerCatConfig}.
 
@@ -550,17 +564,33 @@ get_log_configuration_from_app_env() ->
 get_log_app_env() ->
     application:get_env(rabbit, log, []).
 
--spec normalize_main_log_config(main_log_env(), default_cat_env()) ->
+
+-spec extract_file_rotation_spec(proplists:proplist()) -> file_rotation_spec().
+
+extract_file_rotation_spec(Defaults) ->
+    Spec = lists:filter(fun(Elem) ->
+            case Elem of
+                {rotate_on_date, _}     -> true; 
+                {compress_on_rotate, _} -> true; 
+                {max_no_bytes, _}       -> true; 
+                {max_no_files, _}       -> true; 
+                _ -> false
+            end
+        end, Defaults),
+    SpecMap = proplists:to_map(Spec),
+    SpecMap#{type => file}.
+
+-spec normalize_main_log_config(main_log_env(), default_cat_env(), file_rotation_spec()) ->
     global_log_config().
 
-normalize_main_log_config(Props, DefaultProps) ->
+normalize_main_log_config(Props, DefaultProps, DefaultFileSpec) ->
     Outputs = case proplists:get_value(level, DefaultProps) of
                   undefined -> #{outputs => []};
                   Level     -> #{outputs => [],
                                  level => Level}
               end,
     Props1 = compute_implicitly_enabled_output(Props),
-    normalize_main_log_config1(Props1, Outputs).
+    normalize_main_log_config1(Props1, Outputs, DefaultFileSpec).
 
 compute_implicitly_enabled_output(Props) ->
     {ConsoleEnabled, Props1} = compute_implicitly_enabled_output(
@@ -618,50 +648,51 @@ is_output_explicitely_enabled(FileProps) ->
     is_list(File) orelse (Level =/= undefined andalso Level =/= none).
 
 normalize_main_log_config1([{Type, Props} | Rest],
-                           #{outputs := Outputs} = LogConfig) ->
-    Outputs1 = normalize_main_output(Type, Props, Outputs),
+                           #{outputs := Outputs} = LogConfig,
+                          DefaultFileSpec) ->
+    Outputs1 = normalize_main_output(Type, Props, Outputs, DefaultFileSpec),
     LogConfig1 = LogConfig#{outputs => Outputs1},
-    normalize_main_log_config1(Rest, LogConfig1);
-normalize_main_log_config1([], LogConfig) ->
+    normalize_main_log_config1(Rest, LogConfig1, DefaultFileSpec);
+normalize_main_log_config1([], LogConfig, _) ->
     LogConfig.
 
 -spec normalize_main_output
-(console, console_props(), [logger:handler_config()]) ->
+(console, console_props(), [logger:handler_config()], file_rotation_spec()) ->
     [logger:handler_config()];
-(exchange, exchange_props(), [logger:handler_config()]) ->
+(exchange, exchange_props(), [logger:handler_config()], file_rotation_spec()) ->
     [logger:handler_config()];
-(file, file_props(), [logger:handler_config()]) ->
+(file, file_props(), [logger:handler_config()], file_rotation_spec()) ->
     [logger:handler_config()];
-(journald, journald_props(), [logger:handler_config()]) ->
+(journald, journald_props(), [logger:handler_config()], file_rotation_spec()) ->
     [logger:handler_config()];
-(syslog, syslog_props(), [logger:handler_config()]) ->
+(syslog, syslog_props(), [logger:handler_config()], file_rotation_spec()) ->
     [logger:handler_config()].
 
-normalize_main_output(console, Props, Outputs) ->
+normalize_main_output(console, Props, Outputs, _) ->
     normalize_main_console_output(
       Props,
       #{module => rabbit_logger_std_h,
         config => #{type => standard_io}},
       Outputs);
-normalize_main_output(exchange, Props, Outputs) ->
+normalize_main_output(exchange, Props, Outputs, _) ->
     normalize_main_exchange_output(
       Props,
       #{module => rabbit_logger_exchange_h,
         config => #{}},
       Outputs);
-normalize_main_output(file, Props, Outputs) ->
+normalize_main_output(file, Props, Outputs, DefaultFileSpec) ->
     normalize_main_file_output(
       Props,
       #{module => rabbit_logger_std_h,
-        config => #{type => file}},
+        config => DefaultFileSpec},
       Outputs);
-normalize_main_output(journald, Props, Outputs) ->
+normalize_main_output(journald, Props, Outputs, _) ->
     normalize_main_journald_output(
       Props,
       #{module => systemd_journal_h,
         config => #{}},
       Outputs);
-normalize_main_output(syslog, Props, Outputs) ->
+normalize_main_output(syslog, Props, Outputs, _) ->
     normalize_main_syslog_output(
       Props,
       #{module => syslog_logger_h,
@@ -924,25 +955,30 @@ remove_main_syslog_output(
           (_)                            -> true
       end, Outputs).
 
--spec normalize_per_cat_log_config(per_cat_env()) -> per_cat_log_config().
+-spec normalize_per_cat_log_config(per_cat_env(), file_rotation_spec()) -> per_cat_log_config().
 
-normalize_per_cat_log_config(Props) ->
-    normalize_per_cat_log_config(Props, #{outputs => []}).
+normalize_per_cat_log_config(Props, DefaultFileSpec) ->
+    CatFileSpec = extract_file_rotation_spec(Props),
+    FileSpec = maps:merge(DefaultFileSpec, CatFileSpec),
+    normalize_per_cat_log_config(Props, #{outputs => []}, FileSpec).
 
-normalize_per_cat_log_config([{level, Level} | Rest], LogConfig) ->
+normalize_per_cat_log_config([{level, Level} | Rest], LogConfig, FileSpec) ->
     LogConfig1 = LogConfig#{level => Level},
-    normalize_per_cat_log_config(Rest, LogConfig1);
+    normalize_per_cat_log_config(Rest, LogConfig1, FileSpec);
 normalize_per_cat_log_config([{file, Filename} | Rest],
-                             #{outputs := Outputs} = LogConfig) ->
-    %% Caution: The `file' property in the per-category configuration only
-    %% accepts a filename. It doesn't support the properties of the `file'
-    %% property at the global configuration level.
+                             #{outputs := Outputs} = LogConfig,
+                            FileSpec) ->
+    %% Caution: The `file' property in the per-category configuration doesn't support all properties
+    %% of the `file' property at the global configuration level.
+    %% FileSpec may carry additional file rotation configuration, taken from the `log.default' part
+    %% of the config.
     Output = #{module => rabbit_logger_std_h,
-               config => #{type => file,
-                           file => Filename}},
+               config => FileSpec#{file => Filename}},
     LogConfig1 = LogConfig#{outputs => [Output | Outputs]},
-    normalize_per_cat_log_config(Rest, LogConfig1);
-normalize_per_cat_log_config([], LogConfig) ->
+    normalize_per_cat_log_config(Rest, LogConfig1, FileSpec);
+normalize_per_cat_log_config([_ | Rest], LogConfig, FileSpec) ->
+    normalize_per_cat_log_config(Rest, LogConfig, FileSpec);
+normalize_per_cat_log_config([], LogConfig, _) ->
     LogConfig.
 
 -spec handle_default_and_overridden_outputs(log_config(),


### PR DESCRIPTION
## Proposed Changes

This PR adds log rotation capabilities to the category logs, and expands `default` category to accept and propagate log rotation settings in addition to log level. This fixes a regression in logging config post Lager.

## Types of Changes

- [X] Bug fix (non-breaking change which fixes #4697)
- [X] New feature (non-breaking change which adds defaults propagation to root and category logs)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

To simplify handling I chose to use std_h settings keys instead of the historical log rotation settings as seen in the root log file block. At the same time I minimized change by keeping all historical settings unchanged. That's why you'll see different target keys for `file` and category logs in cuttlefish schema.

I am also interested in back-porting this to v3.9.x, should I do it myself?