### PR TITLE
Add ability to set default vhost limits by pattern

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -632,6 +632,7 @@ end}.
 %% {default_user,        <<"guest">>},
 %% {default_pass,        <<"guest">>},
 %% {default_permissions, [<<".*">>, <<".*">>, <<".*">>]},
+%% {default_limits,      [{vhost, []}]
 
 {mapping, "default_vhost", "rabbit.default_vhost", [
     {datatype, string}
@@ -679,6 +680,63 @@ fun(Conf) ->
     Read      = proplists:get_value(["default_permissions", "read"], Settings),
     Write     = proplists:get_value(["default_permissions", "write"], Settings),
     [list_to_binary(Configure), list_to_binary(Read), list_to_binary(Write)]
+end}.
+
+{mapping, "default_limits.vhost.$id.pattern", "rabbit.default_limits.vhost.$id.pattern", [
+    {include_default, 1},
+    {comment, ".*"},
+    {validators, ["valid_regex"]},
+    {datatype, string}
+]}.
+
+{mapping, "default_limits.vhost.$id.max_connections", "rabbit.default_limits.vhost.$id.max_connections", [
+    {include_default, 1},
+    {comment, 1000},
+    {validators, [ "non_zero_positive_integer"]},
+    {datatype, integer}
+]}.
+
+{mapping, "default_limits.vhost.$id.max_queues", "rabbit.default_limits.vhost.$id.max_queues", [
+    {include_default, 1},
+    {comment, 100},
+    {validators, [ "non_zero_positive_integer"]},
+    {datatype, integer}
+]}.
+
+{translation, "rabbit.default_limits.vhost",
+fun(Conf) ->
+    Prefix = ["default_limits", "vhost"],
+    GetAll = fun(Spec) ->
+                     FullSpec = Prefix ++ Spec,
+                     lists:filtermap(
+                       fun({K, V}) ->
+                               case cuttlefish_variable:is_fuzzy_match(K, FullSpec) of
+                                   true -> [_, _, ID, _] = K,
+                                           {true, {ID, V}};
+                                   _    -> false
+                               end
+                       end,
+                       Conf)
+             end,
+    Get = fun(Spec) -> cuttlefish:conf_get(Prefix ++ Spec, Conf, undefined) end,
+
+    %% Warn about incomplete config
+    SettingIDs = lists:uniq(
+                   [ ID || {ID, _} <- GetAll(["$id", "max_connections"]) ] ++
+                   [ ID || {ID, _} <- GetAll(["$id", "max_queues"]) ]
+                  ),
+    [rabbit_log:warning("No matching pattern for default_limits.vhost.~s", [ID])
+     || ID <- SettingIDs, Get([ID, "pattern"]) =:= undefined],
+
+    %% Transform
+    Settings = [ {P, [{<<"max-connections">>, Get([ID, "max_connections"])},
+                      {<<"max-queues">>,      Get([ID, "max_queues"])}]} ||
+                 {ID, P} <- GetAll(["$id", "pattern"]) ],
+    lists:map(fun({P, L}) ->
+                      NoUndefL = lists:filter(fun({_, V}) -> V =/= undefined end, L),
+                      {ok, MP} = re:compile(P),
+                      {MP, NoUndefL}
+             end, Settings)
 end}.
 
 %% Tags for default user
@@ -2320,3 +2378,9 @@ end}.
 fun(Int) when is_integer(Int) ->
     Int >= 1
 end}.
+
+{validator, "valid_regex", "string must be a valid regular expression",
+ fun("")     -> false;
+    (String) -> {Res, _ } = re:compile(String),
+                Res =:= ok
+ end}.

--- a/deps/rabbit/src/rabbit_vhost_limit.erl
+++ b/deps/rabbit/src/rabbit_vhost_limit.erl
@@ -152,6 +152,8 @@ parse_set(VHost, Defn, ActingUser) ->
                 rabbit_misc:format("Could not parse JSON document: ~tp", [Reason])}
     end.
 
+-spec set(rabbit_types:name(), {binary(), binary()}, rabbit_types:user() | rabbit_types:username()) ->
+    rabbit_runtime_parameters:ok_or_error_string().
 set(VHost, Defn, ActingUser) ->
     rabbit_runtime_parameters:set_any(VHost, <<"vhost-limits">>,
                                       <<"limits">>, Defn, ActingUser).


### PR DESCRIPTION
Limits are defined in the instance config:

    default_limits.vhosts.1.pattern = ^device
    default_limits.vhosts.1.max_connections = 10
    default_limits.vhosts.1.max_queues = 10

    default_limits.vhosts.2.pattern = ^system
    default_limits.vhosts.2.max_connections = 100
    default_limits.vhosts.2.max_queues = -1

    default_limits.vhosts.3.pattern = .*
    default_limits.vhosts.3.max_connections = 20
    default_limits.vhosts.3.max_queues = 20

Where the pattern is regular expression used to match limits to a newly created broker, and the limits are non-negative integers. First matching set of limit is applied, only once, during vhost creation.